### PR TITLE
fix: return to menu

### DIFF
--- a/internal/scene/pet.go
+++ b/internal/scene/pet.go
@@ -17,9 +17,11 @@ import (
 
 type Pet struct {
 	SwitchTo func(Scene)
+	btnMenu  *ui.Button
 	btnFeed  *ui.Button
 	btnBrush *ui.Button
 	btnSleep *ui.Button
+	next     Scene
 	// stats
 	Hunger float64 // 0..100 (0 = full, 100 = hungry)
 	Sleep  float64 // 0..100 (0 = awake, 100 = sleepy)
@@ -32,6 +34,17 @@ type Pet struct {
 
 func NewPet(switchTo func(Scene)) *Pet {
 	p := &Pet{SwitchTo: switchTo, Hunger: 50, Sleep: 50, Mood: 20}
+	p.btnMenu = &ui.Button{
+		X:            26,
+		Y:            18,
+		W:            54,
+		H:            20,
+		Label:        "Menu",
+		BaseColor:    ui.Mint,
+		HoverColor:   ui.Peach,
+		PressedColor: ui.BlushStrong,
+		OnClick:      p.returnToMenu,
+	}
 	p.btnFeed = &ui.Button{
 		X:            26,
 		Y:            178,
@@ -80,6 +93,7 @@ func (p *Pet) Update() (Scene, error) {
 	}
 
 	pointer := readPointerState()
+	p.btnMenu.Update(pointer.x, pointer.y, pointer.down, pointer.justPressed, pointer.justReleased)
 	p.btnFeed.Update(pointer.x, pointer.y, pointer.down, pointer.justPressed, pointer.justReleased)
 	p.btnBrush.Update(pointer.x, pointer.y, pointer.down, pointer.justPressed, pointer.justReleased)
 	p.btnSleep.Update(pointer.x, pointer.y, pointer.down, pointer.justPressed, pointer.justReleased)
@@ -88,11 +102,15 @@ func (p *Pet) Update() (Scene, error) {
 		inpututil.IsKeyJustPressed(ebiten.KeyF),
 		inpututil.IsKeyJustPressed(ebiten.KeyN),
 		inpututil.IsKeyJustPressed(ebiten.KeyB),
+		inpututil.IsKeyJustPressed(ebiten.KeyEscape),
 	)
+	if p.next != nil {
+		return p.next, nil
+	}
 	return p, nil
 }
 
-func (p *Pet) UpdateInputs(feed, sleep, brush bool) {
+func (p *Pet) UpdateInputs(feed, sleep, brush, menu bool) {
 	if feed {
 		p.feed()
 	}
@@ -101,6 +119,9 @@ func (p *Pet) UpdateInputs(feed, sleep, brush bool) {
 	}
 	if brush {
 		p.brush()
+	}
+	if menu {
+		p.returnToMenu()
 	}
 }
 
@@ -142,6 +163,7 @@ func (p *Pet) Draw(screen *ebiten.Image) {
 	drawStatMeter(screen, 123, 34, 74, 38, "Mood", p.Mood, ui.Blush, "heart")
 	drawStatMeter(screen, 212, 34, 74, 38, "Sleep", p.Sleep, ui.BabyBlue, "moon")
 
+	p.btnMenu.Draw(screen)
 	p.btnFeed.Draw(screen)
 	p.btnBrush.Draw(screen)
 	p.btnSleep.Draw(screen)
@@ -166,6 +188,10 @@ func (p *Pet) brush() {
 func (p *Pet) startFeedback(kind string) {
 	p.feedbackKind = kind
 	p.feedbackTicks = 28
+}
+
+func (p *Pet) returnToMenu() {
+	p.next = NewMenu(p.SwitchTo)
 }
 
 func Clamp01(v float64) float64 {

--- a/tests/pet_test.go
+++ b/tests/pet_test.go
@@ -86,7 +86,7 @@ func TestPetInputActions(t *testing.T) {
 	switchTo := func(scene.Scene) {}
 	pet := scene.NewPet(switchTo)
 
-	pet.UpdateInputs(true, false, false)
+	pet.UpdateInputs(true, false, false, false)
 	if pet.Hunger != 48 {
 		t.Errorf("Expected hunger 48 after feed, got %f", pet.Hunger)
 	}
@@ -94,12 +94,12 @@ func TestPetInputActions(t *testing.T) {
 		t.Errorf("Expected mood 19.5 after feed, got %f", pet.Mood)
 	}
 
-	pet.UpdateInputs(false, true, false)
+	pet.UpdateInputs(false, true, false, false)
 	if pet.Sleep != 48 {
 		t.Errorf("Expected sleep 48 after sleep action, got %f", pet.Sleep)
 	}
 
-	pet.UpdateInputs(false, false, true)
+	pet.UpdateInputs(false, false, true, false)
 	if pet.Mood != 17.5 {
 		t.Errorf("Expected mood 17.5 after brush action, got %f", pet.Mood)
 	}
@@ -109,7 +109,7 @@ func TestPetActionsStartFeedback(t *testing.T) {
 	switchTo := func(scene.Scene) {}
 	pet := scene.NewPet(switchTo)
 
-	pet.UpdateInputs(true, false, false)
+	pet.UpdateInputs(true, false, false, false)
 	if pet.T != 0 {
 		t.Errorf("Expected no tick change from input action, got %d", pet.T)
 	}
@@ -123,5 +123,47 @@ func TestPetActionsStartFeedback(t *testing.T) {
 
 	if pet.Hunger >= 50 {
 		t.Errorf("Expected hunger to improve after feed feedback flow, got %f", pet.Hunger)
+	}
+}
+
+func TestPetMenuInputReturnsToMenu(t *testing.T) {
+	switchTo := func(scene.Scene) {}
+	pet := scene.NewPet(switchTo)
+
+	pet.UpdateInputs(false, false, false, true)
+	next, err := pet.Update()
+	if err != nil {
+		t.Fatalf("Update returned error after menu input: %v", err)
+	}
+	if _, ok := next.(*scene.Menu); !ok {
+		t.Fatalf("Expected menu scene after menu input, got %T", next)
+	}
+}
+
+func TestPetMenuReturnAllowsFreshPetState(t *testing.T) {
+	switchTo := func(scene.Scene) {}
+	pet := scene.NewPet(switchTo)
+
+	pet.UpdateInputs(true, true, true, true)
+	next, err := pet.Update()
+	if err != nil {
+		t.Fatalf("Update returned error after menu input: %v", err)
+	}
+	if _, ok := next.(*scene.Menu); !ok {
+		t.Fatalf("Expected menu scene after menu input, got %T", next)
+	}
+
+	freshPet := scene.NewPet(switchTo)
+	if freshPet.Hunger != 50 {
+		t.Errorf("Expected fresh hunger 50, got %f", freshPet.Hunger)
+	}
+	if freshPet.Sleep != 50 {
+		t.Errorf("Expected fresh sleep 50, got %f", freshPet.Sleep)
+	}
+	if freshPet.Mood != 20 {
+		t.Errorf("Expected fresh mood 20, got %f", freshPet.Mood)
+	}
+	if freshPet.T != 0 {
+		t.Errorf("Expected fresh t 0, got %d", freshPet.T)
 	}
 }


### PR DESCRIPTION
Summary

Add a return path from the pet scene back to the main menu using both Escape and a visible Menu button. Returning should create a fresh menu, and starting again from that menu should create a fresh pet scene with default stats.

Key Changes

In internal/scene/pet.go, add a btnMenu *ui.Button and next Scene field to Pet.
Add a small Menu button in the pet scene header area, positioned so it does not overlap the title, stat cards, pet sprite, or bottom action buttons.
Add a returnToMenu() helper that sets p.next = NewMenu(p.SwitchTo).
Update Pet.Update() so:
Escape calls returnToMenu().
The Menu button is updated with pointer state and calls returnToMenu().
If p.next != nil, return that scene from Update().
Extend UpdateInputs to accept a fourth menu bool argument so the Escape/menu transition is testable without relying on Ebiten keyboard state.

Test Plan

Update existing pet input tests to pass false for the new menu argument.
Add a test that calling UpdateInputs(false, false, false, true) followed by Update() returns a *scene.Menu.
Add a reset behavior test by creating a changed Pet, returning to Menu, then confirming a newly created pet starts with defaults: Hunger=50, Sleep=50, Mood=20, T=0.
Run go test ./....